### PR TITLE
BFGS peak-finding routine

### DIFF
--- a/example_bfgs.py
+++ b/example_bfgs.py
@@ -1,0 +1,79 @@
+"""
+Example ThirdWay experimentations.
+"""
+from __future__ import absolute_import, print_function
+import matplotlib.pyplot as plt
+import numpy as np
+from thirdway.lightcurve import LightCurve, generate_lc_depth
+from thirdway.fitting import peak_finder, summed_gaussians, gaussian
+from astropy.utils.console import ProgressBar
+
+# Load light curve from jrad's text archive
+light_curve_path = 'data/kepler17_whole.dat'
+BJDREF = 2454833.
+depth = 0.13413993**2
+jd_minus_bjdref, flux, error = np.loadtxt(light_curve_path, unpack=True)
+jd = jd_minus_bjdref + BJDREF
+
+# construct light curve object from those data
+whole_lc = LightCurve(times=jd, fluxes=flux, errors=error)
+transits = LightCurve(**whole_lc.mask_out_of_transit()).get_transit_light_curves()
+
+# The short cadence data begin after the 137th transit, so ignore all transits before then:
+transits = transits[137:]
+
+plots = False
+
+delta_chi2 = {}#np.zeros(len(transits))
+
+with ProgressBar(len(transits)) as bar:
+    for i, lc in enumerate(transits):
+        #lc.plot()
+        # Remove linear out-of-transit trend from transit
+        lc.remove_linear_baseline()
+        residuals = lc.fluxes - generate_lc_depth(lc.times_jd, depth)
+        
+        best_fit_params = peak_finder(lc.times.jd, residuals, lc.errors)
+        
+        transit_model = generate_lc_depth(lc.times_jd, depth)
+        chi2_transit = np.sum((lc.fluxes - transit_model)**2/lc.errors**2)/len(lc.fluxes)
+
+        gaussian_model = summed_gaussians(lc.times.jd, best_fit_params)
+        
+        if best_fit_params is not None:
+            split_input_parameters = np.split(np.array(best_fit_params), len(best_fit_params)/3)
+            delta_chi2[i] = []
+            for amplitude, t0, sigma in split_input_parameters:
+                model_i= gaussian(lc.times.jd, amplitude, t0, sigma)
+                chi2_bumps = np.sum((lc.fluxes - transit_model - model_i)**2/lc.errors**2)/len(lc.fluxes)
+                delta_chi2[i].append(np.abs(chi2_transit - chi2_bumps))
+        
+        if plots:
+            fig, ax = plt.subplots(3, 1, figsize=(8, 14), sharex=True)
+            
+            ax[0].errorbar(lc.times.jd, lc.fluxes, lc.errors, fmt='.', color='k')
+            ax[0].plot(lc.times.jd, transit_model, 'r')
+            ax[0].set(ylabel='Flux')
+            
+            ax[1].axhline(0, color='gray', ls='--')
+            ax[1].errorbar(lc.times.jd, lc.fluxes - transit_model, fmt='.', color='k')
+            ax[1].plot(lc.times.jd, gaussian_model, color='r')
+            ax[1].set_ylabel('Transit Residuals')
+            
+            ax[2].axhline(0, color='gray', ls='--')
+            ax[2].errorbar(lc.times.jd, lc.fluxes - transit_model - gaussian_model, fmt='.', color='k')
+            ax[2].set_ylabel('Gaussian Residuals')
+            ax[2].set_title(r'$Delta \chi^2$ = '+'{0}'.format(delta_chi2[i]))
+            
+            fig.tight_layout()
+            fig.savefig('plots/{0:03d}.png'.format(i), bbox_inches='tight')
+            #plt.show()
+            fig.close()
+        
+        bar.update()
+        
+all_delta_chi2 = np.concatenate(delta_chi2.values()).ravel()
+
+fig, ax = plt.subplots(1,figsize=(12, 6))
+ax.plot(np.log10(all_delta_chi2), '.')
+plt.show()

--- a/thirdway/fitting.py
+++ b/thirdway/fitting.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import, print_function
 import numpy as np
 import emcee
 from .lightcurve import params
-
+from scipy import optimize, signal
+import matplotlib.pyplot as plt
 
 def gaussian(times, amplitude, t0, sigma):
     return amplitude * np.exp(-0.5*(times - t0)**2/sigma**2)
-
 
 def summed_gaussians(times, input_parameters):
     """
@@ -15,9 +15,10 @@ def summed_gaussians(times, input_parameters):
     sum of all of those gaussians.
     """
     model = np.zeros(len(times), dtype=np.float64)
-    split_input_parameters = np.split(np.array(input_parameters), len(input_parameters)/3)
-    for amplitude, t0, sigma in split_input_parameters:
-        model += gaussian(times, amplitude, t0, sigma)
+    if input_parameters is not None:
+        split_input_parameters = np.split(np.array(input_parameters), len(input_parameters)/3)
+        for amplitude, t0, sigma in split_input_parameters:
+            model += gaussian(times, amplitude, t0, sigma)
 
     return model
 
@@ -43,6 +44,8 @@ def get_in_transit_bounds(x, params=params, duration_fraction=0.7):
     phased = (x - params.t0) % params.per
     near_transit = ((phased < params.duration*(0.5*duration_fraction)) |
                     (phased > params.per - params.duration*(0.5*duration_fraction)))
+    if np.count_nonzero(near_transit) == 0:
+        near_transit = 0
     return (x[near_transit].min(), x[near_transit].max())
 
 
@@ -57,6 +60,28 @@ def lnprior(theta, y, lower_t_bound, upper_t_bound):
         return 0.0
     return -np.inf
 
+#def fmin_fitter(times, residuals, errors):
+#    n_peaks = 4
+#    peak_times = np.linspace(times.min(), times.max(), n_peaks+2)[1:-1]
+#    peak_amplitudes = n_peaks*[2*np.std(residuals)]
+#    peak_sigmas = n_peaks*[5./60/24] # 5 min
+#    input_parameters = np.vstack([peak_amplitudes, peak_times, peak_sigmas]).T.ravel()
+#    
+#    min_t, max_t = get_in_transit_bounds(times)
+#    times_bounds = n_peaks*[(min_t, max_t)]
+#    amplitudes_bounds = n_peaks*[(0, 1)]
+#    sigmas_bounds = n_peaks*[(1./60/24, max_t - min_t)]
+#    #bounds = np.vstack([amplitudes_bounds, times_bounds, sigmas_bounds]).T.ravel()
+#    bounds = []
+#    for i, j, k in zip(amplitudes_bounds, times_bounds, sigmas_bounds):
+#        bounds.extend([i, j, k])
+#    
+#    print('bounds shape: {0}'.format(np.shape(bounds)), '\ninputs: {0}'.format(input_parameters.shape))
+#    def chi2(*args, **kwargs):
+#        return -2*lnlike(*args, **kwargs)
+#    results = optimize.fmin_l_bfgs_b(chi2, input_parameters, bounds=bounds, 
+#                                     args=(times, residuals, errors), approx_grad=True)
+#    return results
 
 def lnlike(theta, x, y, yerr):
     model = summed_gaussians(x, theta)
@@ -95,8 +120,69 @@ def run_emcee(times, residuals, errors, n_peaks=4, burnin=0.7):
     pool = emcee.interruptible_pool.InterruptiblePool(processes=4)
     sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob, args=(times, residuals, errors, lower_t_bound, upper_t_bound),
                                     pool=pool)
-    n_steps = 20000
+    n_steps = 25000
     sampler.run_mcmc(pos, n_steps)
     burnin_len = int(burnin*n_steps)
     samples = sampler.chain[:, burnin_len:, :].reshape((-1, ndim))
     return sampler, samples
+
+       
+def chi2(theta, x, y, yerr):
+    model = summed_gaussians(x, theta)
+    return np.sum((y-model)**2/yerr**2)
+
+def peak_finder(times, residuals, errors, n_peaks=4, plots=False, verbose=False):
+    # http://stackoverflow.com/a/25666951
+    # Convolve residuals with a gaussian, find relative maxima
+    n_points_kernel = 100
+    window = signal.general_gaussian(n_points_kernel+1, p=1, sig=12)
+    filtered = signal.fftconvolve(window, residuals)
+    filtered = (np.average(residuals) / np.average(filtered)) * filtered
+    filtered = np.roll(filtered, -n_points_kernel/2)
+    maxes = signal.argrelmax(filtered)[0]
+    maxes = maxes[maxes < len(residuals)]
+    maxes = maxes[residuals[maxes] > 0]
+
+
+    lower_t_bound, upper_t_bound = get_in_transit_bounds(times)
+    maxes_in_transit = maxes[(times[maxes] < upper_t_bound) & 
+                             (times[maxes] > lower_t_bound)]
+
+    if len(maxes_in_transit) == 0:
+        if verbose: 
+            print('no maxes found')
+        return None
+
+    peak_times = times[maxes_in_transit]
+    peak_amplitudes = residuals[maxes_in_transit]#len(peak_times)*[3*np.std(residuals)]
+    peak_sigmas = len(peak_times)*[4./60/24] # 5 min
+    input_parameters = np.vstack([peak_amplitudes, peak_times, peak_sigmas]).T.ravel()
+    #result = optimize.fmin(chi2, input_parameters, args=(times, residuals, errors))
+    result = optimize.fmin_bfgs(chi2, input_parameters, disp=False, 
+                                args=(times, residuals, errors))        
+    #print(result, result == input_parameters)
+    
+    if plots:
+        fig, ax = plt.subplots(3, 1, figsize=(8, 10), sharex=True)
+    
+        ax[0].errorbar(times, residuals, fmt='.', color='k')
+        [ax[0].axvline(t) for t in times[maxes_in_transit]]
+        ax[0].plot(times, summed_gaussians(times, input_parameters), 'r')
+        #ax[1].errorbar(times, gaussian_model, fmt='.', color='r')
+        ax[0].axhline(0, color='k', ls='--')
+        ax[0].set_ylabel('Transit Residuals')
+    
+        ax[1].errorbar(times, residuals, fmt='.', color='k')
+        ax[1].plot(times, summed_gaussians(times, result), 'r')
+        #ax[1].errorbar(times, gaussian_model, fmt='.', color='r')
+        ax[1].axhline(0, color='k', ls='--')
+        ax[1].set_ylabel('Residuals')
+    
+        ax[2].errorbar(times, residuals - summed_gaussians(times, result), fmt='.', color='k')
+        #ax[1].errorbar(times, gaussian_model, fmt='.', color='r')
+        ax[2].axhline(0, color='k', ls='--')
+        ax[2].set_ylabel('Residuals')
+
+        fig.tight_layout()
+        plt.show()
+    return result


### PR DESCRIPTION
Today I've added a fast alternative spot detection/fitting method to the cumbersome `emcee` option. It goes like this: 
1. Remove assumed transit light curve. Again, I'm not fitting the transit, just assuming that the @jradavenport parameters are good. Then convolve the residuals with a gaussian (smoothing).
2. Use [`scipy.signal.argrelmax`](http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.signal.argrelmax.html) to find relative maxima (bumps!) in the smoothed residuals after ingress and before egress. This procedure takes some tuning parameters that I've tweaked to mostly work (i.e. gaussian kernel width). Unlike the MCMC routine, I don't set a number of spots to find. The broad gaussian convolution ensures that there are a small number of spots detected in each light curve. 
3. Calculate Delta chi^2 for each Gaussian bump – I'm hoping to use this as a metric to identify significant spot-crossings as opposed to spurious bump detections.

I haven't yet settled on a Delta chi^2 threshold that works best, but I've experimented a bunch to convince myself that it's doing what I expect it to. This runs on all short cadence transit light curves in <20 seconds.

Here's a sample result:

![229](https://cloud.githubusercontent.com/assets/3497584/11923728/888bfa56-a75c-11e5-84f4-9fa082d84f89.png)
